### PR TITLE
#22

### DIFF
--- a/app/src/main/java/com/montaigne/montaigneapp/activity/AbstractActivity.java
+++ b/app/src/main/java/com/montaigne/montaigneapp/activity/AbstractActivity.java
@@ -1,6 +1,7 @@
 package com.montaigne.montaigneapp.activity;
 
 import android.os.Bundle;
+import android.util.Log;
 import android.widget.Button;
 
 import androidx.annotation.Nullable;
@@ -11,8 +12,11 @@ public abstract class AbstractActivity extends AppCompatActivity {
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        initializeViews();
+        if (initializeViews()) {  // teste obrigatório para testar a inicialização das views
+            throw new AssertionError("Erro ao inicializar views");
+        }
     }
 
-    protected abstract void initializeViews();
+    protected abstract boolean initializeViews();
+    // deve retornar true se uma view de teste for nula
 }

--- a/app/src/main/java/com/montaigne/montaigneapp/activity/carimboDefinitivo/CarimboDefinitivoActivity.java
+++ b/app/src/main/java/com/montaigne/montaigneapp/activity/carimboDefinitivo/CarimboDefinitivoActivity.java
@@ -29,7 +29,7 @@ public class CarimboDefinitivoActivity extends AbstractActivity {
         CarimboDefinitivoVM viewModel = new CarimboDefinitivoVM(this);
     }
 
-    protected void initializeViews() {
+    protected boolean initializeViews() {
         buttonContinuarCarimbo = findViewById(R.id.buttonContinueCarimbo);
         imageButtonHome = findViewById(R.id.imageButtonHome);
         imageButtonCamera = findViewById(R.id.imageButtonPhoto);
@@ -60,5 +60,7 @@ public class CarimboDefinitivoActivity extends AbstractActivity {
                 (ImageButton)findViewById(R.id.imageButtonHelpReferenciaNivel));
         buttonsHelp.put(fields.get ("NomeProjeto"),
                 (ImageButton) findViewById(R.id.imageButtonHelpCliente));
+
+        return imageButtonCamera == null;
     }
 }

--- a/app/src/main/java/com/montaigne/montaigneapp/activity/carimboDefinitivo/CarimboDefinitivoActivity.java
+++ b/app/src/main/java/com/montaigne/montaigneapp/activity/carimboDefinitivo/CarimboDefinitivoActivity.java
@@ -23,13 +23,13 @@ public class CarimboDefinitivoActivity extends AbstractActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_carimbo_definitivo);
 
-        initializeViews();
         CarimboDefinitivoVM viewModel = new CarimboDefinitivoVM(this);
     }
 
     protected boolean initializeViews() {
+        setContentView(R.layout.activity_carimbo_definitivo);
+
         buttonContinuarCarimbo = findViewById(R.id.buttonContinueCarimbo);
         imageButtonHome = findViewById(R.id.imageButtonHome);
         imageButtonCamera = findViewById(R.id.imageButtonPhoto);

--- a/app/src/main/java/com/montaigne/montaigneapp/activity/home/HomeActivity.java
+++ b/app/src/main/java/com/montaigne/montaigneapp/activity/home/HomeActivity.java
@@ -15,17 +15,18 @@ public class HomeActivity extends AbstractActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_home);
-
-        initializeViews();
 
         HomeVM viewModel = new HomeVM(this);
     }
 
     @Override
-    protected void initializeViews() {
+    protected boolean initializeViews() {
+        setContentView(R.layout.activity_home);
+
         newProjectFab = findViewById(R.id.fabNewProjeto);
         recyclerProjetoCategorias = findViewById(R.id.recyclerCategorias);
         recyclerProjetosSalvos = findViewById(R.id.recyclerProjetosSalvos);
+
+        return newProjectFab == null;
     }
 }

--- a/app/src/main/java/com/montaigne/montaigneapp/activity/spt/carimboUnico/CarimboUnicoActivity.java
+++ b/app/src/main/java/com/montaigne/montaigneapp/activity/spt/carimboUnico/CarimboUnicoActivity.java
@@ -28,7 +28,7 @@ public class CarimboUnicoActivity extends AbstractActivity {
     }
 
     @Override
-    protected void initializeViews() {
+    protected boolean initializeViews() {
         buttonPegarLocalizacao = findViewById(R.id.buttonGetLocation);
         buttonIniciarEnsaio = findViewById(R.id.buttonStartEnsaio);
         editTextDataInicio = findViewById(R.id.editTextStartDate);
@@ -37,5 +37,7 @@ public class CarimboUnicoActivity extends AbstractActivity {
         imageButtonHelpDataInicio = findViewById(R.id.imageButtonHelpStartDate);
         imageButtonHelpNivelFuro = findViewById(R.id.imageButtonHelpNivelFuro);
         imageButtonHome = findViewById(R.id.imageButtonHome);
+
+        return buttonIniciarEnsaio == null;
     }
 }

--- a/app/src/main/java/com/montaigne/montaigneapp/activity/spt/carimboUnico/CarimboUnicoActivity.java
+++ b/app/src/main/java/com/montaigne/montaigneapp/activity/spt/carimboUnico/CarimboUnicoActivity.java
@@ -21,14 +21,14 @@ public class CarimboUnicoActivity extends AbstractActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_carimbo_unico);
 
-        initializeViews();
         CarimboUnicoVM viewModel = new CarimboUnicoVM(this);
     }
 
     @Override
     protected boolean initializeViews() {
+        setContentView(R.layout.activity_carimbo_unico);
+
         buttonPegarLocalizacao = findViewById(R.id.buttonGetLocation);
         buttonIniciarEnsaio = findViewById(R.id.buttonStartEnsaio);
         editTextDataInicio = findViewById(R.id.editTextStartDate);

--- a/app/src/main/java/com/montaigne/montaigneapp/activity/spt/ensaio/EnsaioActivity.java
+++ b/app/src/main/java/com/montaigne/montaigneapp/activity/spt/ensaio/EnsaioActivity.java
@@ -35,19 +35,24 @@ public class EnsaioActivity extends AbstractActivity {
 
         textAmostraN = findViewById(R.id.textAmostraN);
         editTextProfundidade = findViewById(R.id.editTextProfundidade);
+
         golpes.add(findViewById(R.id.editTextGolpe1));
         golpes.add(findViewById(R.id.editTextGolpe2));
         golpes.add(findViewById(R.id.editTextGolpe3));
+
         penetracoes.add(findViewById(R.id.editTextPenetracao1));
         penetracoes.add(findViewById(R.id.editTextPenetracao2));
         penetracoes.add(findViewById(R.id.editTextPenetracao3));
+
         editTextNivelAgua = findViewById(R.id.editTextNivelAgua);
         buttonFinalizarFuro = findViewById(R.id.buttonFinishFuro);
         imageButtonHome = findViewById(R.id.imageButtonHome);
         imageButtonHelpNivelAgua = findViewById(R.id.imageButtonHelpNivelAgua);
+
         buttonsDecrementGolpes.add(findViewById(R.id.imageButtonIcrementGolpe1));
         buttonsDecrementGolpes.add(findViewById(R.id.imageButtonIcrementGolpe2));
         buttonsDecrementGolpes.add(findViewById(R.id.imageButtonIcrementGolpe3));
+
         buttonsIncrementGolpes.add(findViewById(R.id.imageButtonDecrementGolpe1));
         buttonsIncrementGolpes.add(findViewById(R.id.imageButtonDecrementGolpe2));
         buttonsIncrementGolpes.add(findViewById(R.id.imageButtonDecrementGolpe3));

--- a/app/src/main/java/com/montaigne/montaigneapp/activity/spt/ensaio/EnsaioActivity.java
+++ b/app/src/main/java/com/montaigne/montaigneapp/activity/spt/ensaio/EnsaioActivity.java
@@ -25,14 +25,14 @@ public class EnsaioActivity extends AbstractActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_ensaio);
 
-        initializeViews();
         EnsaioVM viewModel = new EnsaioVM(this);
     }
 
     @Override
     protected boolean initializeViews() {
+        setContentView(R.layout.activity_ensaio);
+
         textAmostraN = findViewById(R.id.textAmostraN);
         editTextProfundidade = findViewById(R.id.editTextProfundidade);
         golpes.add(findViewById(R.id.editTextGolpe1));

--- a/app/src/main/java/com/montaigne/montaigneapp/activity/spt/ensaio/EnsaioActivity.java
+++ b/app/src/main/java/com/montaigne/montaigneapp/activity/spt/ensaio/EnsaioActivity.java
@@ -32,7 +32,7 @@ public class EnsaioActivity extends AbstractActivity {
     }
 
     @Override
-    protected void initializeViews() {
+    protected boolean initializeViews() {
         textAmostraN = findViewById(R.id.textAmostraN);
         editTextProfundidade = findViewById(R.id.editTextProfundidade);
         golpes.add(findViewById(R.id.editTextGolpe1));
@@ -52,6 +52,7 @@ public class EnsaioActivity extends AbstractActivity {
         buttonsIncrementGolpes.add(findViewById(R.id.imageButtonDecrementGolpe2));
         buttonsIncrementGolpes.add(findViewById(R.id.imageButtonDecrementGolpe3));
 
+        return textAmostraN == null;
     }
 }
 

--- a/app/src/main/java/com/montaigne/montaigneapp/activity/spt/furo/FuroActivity.java
+++ b/app/src/main/java/com/montaigne/montaigneapp/activity/spt/furo/FuroActivity.java
@@ -30,11 +30,13 @@ public class FuroActivity extends AbstractActivity {
     }
 
     @Override
-    protected void initializeViews() {
+    protected boolean initializeViews() {
         buttonAddAmostra = findViewById(R.id.imageButtonAddAmostra);
         buttonDeleteAmostra = findViewById(R.id.imageButtonDeleteAmostra);
         buttonPrint = findViewById(R.id.buttonPrint);
         recyclerAmostras = findViewById(R.id.recyclerAmostra);
         textAmostra = findViewById(R.id.textAmostra);
+
+        return buttonAddAmostra == null;
     }
 }

--- a/app/src/main/java/com/montaigne/montaigneapp/activity/spt/furo/FuroActivity.java
+++ b/app/src/main/java/com/montaigne/montaigneapp/activity/spt/furo/FuroActivity.java
@@ -20,9 +20,6 @@ public class FuroActivity extends AbstractActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.acitivity_furo);
-
-        initializeViews();
 
         String nome = getIntent().getStringExtra("name");
         textAmostra.setText(nome);
@@ -31,6 +28,8 @@ public class FuroActivity extends AbstractActivity {
 
     @Override
     protected boolean initializeViews() {
+        setContentView(R.layout.acitivity_furo);
+
         buttonAddAmostra = findViewById(R.id.imageButtonAddAmostra);
         buttonDeleteAmostra = findViewById(R.id.imageButtonDeleteAmostra);
         buttonPrint = findViewById(R.id.buttonPrint);

--- a/app/src/main/java/com/montaigne/montaigneapp/activity/spt/projeto/ProjetoActivity.java
+++ b/app/src/main/java/com/montaigne/montaigneapp/activity/spt/projeto/ProjetoActivity.java
@@ -30,11 +30,13 @@ public class ProjetoActivity extends AbstractActivity {
     }
 
     @Override
-    protected void initializeViews() {
+    protected boolean initializeViews() {
         recyclerFuros = findViewById(R.id.recyclerFuro);
         buttonDeleteFuro = findViewById(R.id.imageButtonDeleteFuro);
         buttonAddFuro = findViewById(R.id.imageButtonAddFuro);
         textFuro = findViewById(R.id.textFuro);  // adicionado apenas pela atual ausência
         // de título na activity
+
+        return recyclerFuros == null;
     }
 }

--- a/app/src/main/java/com/montaigne/montaigneapp/activity/spt/projeto/ProjetoActivity.java
+++ b/app/src/main/java/com/montaigne/montaigneapp/activity/spt/projeto/ProjetoActivity.java
@@ -18,9 +18,6 @@ public class ProjetoActivity extends AbstractActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_projeto);
-
-        initializeViews();
 
         String nome = getIntent().getStringExtra("name");
         // talvez seja uma boa usar enum para padronizar os nomes dos extras em intents
@@ -31,6 +28,8 @@ public class ProjetoActivity extends AbstractActivity {
 
     @Override
     protected boolean initializeViews() {
+        setContentView(R.layout.activity_projeto);
+
         recyclerFuros = findViewById(R.id.recyclerFuro);
         buttonDeleteFuro = findViewById(R.id.imageButtonDeleteFuro);
         buttonAddFuro = findViewById(R.id.imageButtonAddFuro);


### PR DESCRIPTION
closes #22 

Foi mantida a estrutura com `AbstractActiviy`, embora  agora o código se certifica que `setContentView()` fosse chamado antes de inicializar as views. Para fazer isto a seguinte alteração foi necessária:

**Importante:** agora é necessário chamar `setContentView()` dentro da `initializeViews()`, antes de começar o processo de inicialização e depois retornar true se alguma view de teste teve valor nulo, para garantir que tudo foi inicializado corretamente.

Exemplo:
``` java
protected boolean initializeViews() {
   setContentView(R.layout.my_activity);

   button = findViewById(R.id.myButton);
   text = findViewById(r.id.myTextView);

   return button == null;
}
```

**Para o caso de mais de uma view, escolha uma com id que não aparece em outros layouts.**

Isto para garantir que foi selecionado o layout certo e não haver ambiguidades.

As activities atuais já foram modificadas em conformidade com a classe abstrata.