### PR TITLE
Persistência em disco

### DIFF
--- a/app/src/main/java/com/montaigne/montaigneapp/data/dao/ProjetoSptDao.java
+++ b/app/src/main/java/com/montaigne/montaigneapp/data/dao/ProjetoSptDao.java
@@ -7,10 +7,20 @@ import com.google.firebase.database.FirebaseDatabase;
 import com.montaigne.montaigneapp.model.spt.ProjetoSpt;
 
 public class ProjetoSptDao {
-    private DatabaseReference dbReference;
+    private final DatabaseReference dbReference;
+    private static ProjetoSptDao singleton;
 
-    public ProjetoSptDao() {
-        dbReference = FirebaseDatabase.getInstance().getReference().child("projetos").child("spt");
+    private ProjetoSptDao() {
+        FirebaseDatabase fdb = FirebaseDatabase.getInstance();
+        fdb.setPersistenceEnabled(true);
+        dbReference = fdb.getReference().child("projetos").child("spt");
+        dbReference.keepSynced(true);
+    }
+
+    public static ProjetoSptDao getInstance() {
+        if (singleton == null)
+            singleton = new ProjetoSptDao();
+        return singleton;
     }
 
     public DatabaseReference getDbReference() {

--- a/app/src/main/java/com/montaigne/montaigneapp/data/usecase/AmostraSptUseCase.java
+++ b/app/src/main/java/com/montaigne/montaigneapp/data/usecase/AmostraSptUseCase.java
@@ -7,6 +7,7 @@ import com.montaigne.montaigneapp.model.spt.ProjetoSpt;
 
 import java.util.List;
 
+@Deprecated
 public class AmostraSptUseCase {
     public static Task<Void> save(int idFuro, AmostraSpt amostraSpt, ProjetoSpt projetoSpt) {
         List<FuroSpt> listaDeFuros = projetoSpt.getListaDeFuros();

--- a/app/src/main/java/com/montaigne/montaigneapp/data/usecase/FuroSptUseCase.java
+++ b/app/src/main/java/com/montaigne/montaigneapp/data/usecase/FuroSptUseCase.java
@@ -6,6 +6,7 @@ import com.montaigne.montaigneapp.model.spt.ProjetoSpt;
 
 import java.util.List;
 
+@Deprecated
 public class FuroSptUseCase {
     public static Task<Void> save(FuroSpt furoSpt, ProjetoSpt projetoSpt) {
         List<FuroSpt> listaDeFuros = projetoSpt.getListaDeFuros();

--- a/app/src/main/java/com/montaigne/montaigneapp/data/usecase/ProjetoSptUseCase.java
+++ b/app/src/main/java/com/montaigne/montaigneapp/data/usecase/ProjetoSptUseCase.java
@@ -8,27 +8,27 @@ import com.montaigne.montaigneapp.model.spt.ProjetoSpt;
 
 public class ProjetoSptUseCase {
     public static DatabaseReference getDatabase() {
-        ProjetoSptDao projetoSptDao = new ProjetoSptDao();
+        ProjetoSptDao projetoSptDao = ProjetoSptDao.getInstance();
         return projetoSptDao.getDbReference();
     }
 
     public static Task<Void> save(ProjetoSpt projetoSpt) {
-        ProjetoSptDao projetoSptDao = new ProjetoSptDao();
+        ProjetoSptDao projetoSptDao = ProjetoSptDao.getInstance();
         return projetoSptDao.insertProjeto(projetoSpt);
     }
 
     public static Task<Void> update(ProjetoSpt projetoSpt) {
-        ProjetoSptDao projetoSptDao = new ProjetoSptDao();
+        ProjetoSptDao projetoSptDao = ProjetoSptDao.getInstance();
         return projetoSptDao.updateProjeto(projetoSpt);
     }
 
     public static Task<Void> delete(ProjetoSpt projetoSpt) {
-        ProjetoSptDao projetoSptDao = new ProjetoSptDao();
+        ProjetoSptDao projetoSptDao = ProjetoSptDao.getInstance();
         return  projetoSptDao.deleteProjetoById(projetoSpt.getId());
     }
 
     public static Task<DataSnapshot> read() {
-        ProjetoSptDao projetoSptDao = new ProjetoSptDao();
+        ProjetoSptDao projetoSptDao = ProjetoSptDao.getInstance();
         return projetoSptDao.getProjetos();
     }
 }


### PR DESCRIPTION
Transforma o Dao num singleton o que permite que a persistência offline seja ativada. O método [`keepSynced(true)` ](https://firebase.google.com/docs/database/android/offline-capabilities?hl=pt-br#section-prioritizing-the-local-cache) também permitiu que as alterações sejam feitas no banco de dados local ao invés de só salva-las e publica-las depois.

Como no front end estamos passando todas as alterações diretamente para um `ProjetoSpt` e fazendo as operações do banco de dados apenas nele, essa branch também marca `FuroSptUseCase` e `AmostrSptUseCase` como `@Deprecated` que podem ser apagadas futuramente.

Este PR não resolve a issue #59.